### PR TITLE
Fix login API 500 error

### DIFF
--- a/api/login/index.js
+++ b/api/login/index.js
@@ -19,10 +19,12 @@ const JWT_SECRET = process.env.JWT_SECRET;
 module.exports = async function (context, req) {
     try {
         // Enable CORS
-        context.res.headers = {
-            'Access-Control-Allow-Origin': '*',
-            'Access-Control-Allow-Methods': 'POST, OPTIONS',
-            'Access-Control-Allow-Headers': 'Content-Type'
+        context.res = {
+            headers: {
+                'Access-Control-Allow-Origin': '*',
+                'Access-Control-Allow-Methods': 'POST, OPTIONS',
+                'Access-Control-Allow-Headers': 'Content-Type'
+            }
         };
 
         // Handle preflight requests


### PR DESCRIPTION
## Summary
- initialize `context.res` correctly before setting headers in `api/login`

## Testing
- `npm test --prefix api` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_6856ef4fff3083308558336121fe3f48